### PR TITLE
fix(deps): patch 2 critical, 8 high, and related security alerts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
           path: build/reports/jacoco/
 
       - name: SonarCloud Analysis
-        uses: SonarSource/sonarqube-scan-action@v5.2.0
+        uses: SonarSource/sonarqube-scan-action@v6.0.0
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN_2 }}
         with:

--- a/package-lock.json
+++ b/package-lock.json
@@ -766,9 +766,9 @@
       }
     },
     "node_modules/basic-ftp": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.0.5.tgz",
-      "integrity": "sha512-4Bcg1P8xhUuqcii/S0Z9wiHIrQVPMermM1any+MX5GeGD7faD3/msQUDGLol9wOcz4/jbg/WJnGqoJF6LiBdtg==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.2.2.tgz",
+      "integrity": "sha512-1tDrzKsdCg70WGvbFss/ulVAxupNauGnOlgpyjKzeQxzyllBLS0CGLV7tjIXTK3ZQA9/FBEm9qyFFN1bciA6pw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1305,9 +1305,9 @@
       }
     },
     "node_modules/defu": {
-      "version": "6.1.4",
-      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.4.tgz",
-      "integrity": "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==",
+      "version": "6.1.5",
+      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.5.tgz",
+      "integrity": "sha512-pwdBJxJuJXmqrLO6s0VBmfbRz+G7FUzkjldAsdi9Yrv86mPyzq0ll1o8+8gB4Gsr6GJHbK1Lh3ngllgTInDCjA==",
       "dev": true,
       "license": "MIT"
     },
@@ -1604,9 +1604,9 @@
       }
     },
     "node_modules/handlebars": {
-      "version": "4.7.8",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
-      "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+      "version": "4.7.9",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+      "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1896,9 +1896,9 @@
       "license": "MIT"
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -2274,16 +2274,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/os-tmpdir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/pac-proxy-agent": {
@@ -2903,16 +2893,13 @@
       }
     },
     "node_modules/tmp": {
-      "version": "0.0.33",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "os-tmpdir": "~1.0.2"
-      },
       "engines": {
-        "node": ">=0.6.0"
+        "node": ">=14.14"
       }
     },
     "node_modules/tslib": {
@@ -2957,9 +2944,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.21.2",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.2.tgz",
-      "integrity": "sha512-uROZWze0R0itiAKVPsYhFov9LxrPMHLMEQFszeI2gCN6bnIIZ8twzBCJcN2LJrBBLfrP0t1FW0g+JmKVl8Vk1g==",
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
+      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -2,5 +2,13 @@
   "devDependencies": {
     "@release-it/conventional-changelog": "^10.0.1",
     "release-it": "^19.0.1"
+  },
+  "overrides": {
+    "handlebars": "4.7.9",
+    "basic-ftp": "5.2.2",
+    "lodash": "4.18.1",
+    "defu": "6.1.5",
+    "undici": "6.27.0",
+    "tmp": "0.2.7"
   }
 }


### PR DESCRIPTION
## Summary

Patches the critical/high Dependabot security alerts currently open on `main` by bumping the affected npm packages (pinned via `overrides` in `package.json`, since they're transitive deps of `release-it` / `@release-it/conventional-changelog`, not direct dependencies) and the `SonarSource/sonarqube-scan-action` GitHub Action pin.

`release-it` and `@release-it/conventional-changelog` themselves are **untouched** (still `^19.0.1` / `^10.0.1`) — verified via `npm ci --dry-run` that the lockfile is fully consistent with `package.json` after the bump.

### npm packages (via `package.json` → `overrides`)

| Package | Old → New | Vulnerability class fixed |
|---|---|---|
| `handlebars` | 4.7.8 → **4.7.9** | Critical + high: JS Injection via AST Type Confusion (multiple GHSA advisories, tampered `@partial-block`, dynamic partials, CLI precompiler) |
| `basic-ftp` | 5.0.5 → **5.2.2** | Critical: Path Traversal in `downloadToDir()`. High: incomplete CRLF injection protection allowing arbitrary FTP command execution via credentials/MKD |
| `lodash` | 4.17.21 → **4.18.1** | High: Code Injection via `_.template` imports key names. Moderate: Prototype Pollution via `_.unset`/`_.omit`. Note: the requested target `4.18.0` is flagged **"Bad release"** by npm itself (`npm view lodash@4.18.0 deprecated`) — used `4.18.1` (latest, same fix) instead |
| `defu` | 6.1.4 → **6.1.5** | High: Prototype pollution via `__proto__` key in defaults argument |
| `undici` | 6.21.2 → **6.27.0** | High: malicious WebSocket 64-bit length overflow crashes the client. Also closes 3 additional currently-open Dependabot alerts on `undici` (moderate Set-Cookie header injection, low keep-alive queue poisoning, low SameSite downgrade) that would have stayed open at the originally-targeted 6.24.0 |
| `tmp` | 0.0.33 → **0.2.7** | High: Path Traversal via unsanitized prefix/postfix enabling directory escape. Note: the requested target `0.2.6` is itself affected by a newly disclosed high-severity type-confusion path-traversal bypass (`>=0.2.6 <0.2.7`) — used `0.2.7` instead |

### GitHub Action

| Action | Old → New | Vulnerability class fixed |
|---|---|---|
| `SonarSource/sonarqube-scan-action` | v5.2.0 → **v6.0.0** | High: Argument Injection. High: Command Injection |

### Out of scope (noted, not fixed here)

A few additional open Dependabot alerts exist that were **not** part of this change's scope (lower severity, or would require a major-version bump of a direct dependency):
- `ip-address` (moderate, XSS in `Address6` HTML-emitting methods, transitive via `release-it`/`proxy-agent`)
- `picomatch` (high, glob matching bypass, transitive)
- `@conventional-changelog/git-client` (moderate, argument injection, transitive)
- `basic-ftp` has two additional high-severity DoS advisories (unbounded memory in `Client.list()`, unbounded multiline buffering) that are only fixed in `basic-ftp@6.x` — a major bump not requested here and not currently flagged as an open Dependabot alert on this repo
- `SonarSource/sonarqube-scan-action@v7.0.0` is available (there's already an open Dependabot branch `dependabot/github_actions/SonarSource/sonarqube-scan-action-7.0.0`) — that's a feature bump beyond the security-patched `v6.0.0`, left for a separate PR

Happy to follow up with a second PR for these if wanted.

## Test plan

- [x] `npm ci --dry-run` confirms `package-lock.json` is fully in sync with `package.json` (no drift)
- [x] `npm ls` confirms `release-it` and `@release-it/conventional-changelog` versions are unchanged
- [x] `npm ls handlebars basic-ftp lodash defu undici tmp --all` confirms all six resolve to the intended patched versions
- [x] `npm audit` no longer lists any of the six packages above
- [ ] No build/test was run per repo owner's standing instruction — CI will validate on this PR
